### PR TITLE
feat: Hook function insert

### DIFF
--- a/src/main/kotlin/com/github/nvelychenko/drupalextend/completion/providers/HookAttributeCompletionProvider.kt
+++ b/src/main/kotlin/com/github/nvelychenko/drupalextend/completion/providers/HookAttributeCompletionProvider.kt
@@ -1,21 +1,32 @@
 package com.github.nvelychenko.drupalextend.completion.providers
 
-import com.intellij.codeInsight.completion.CompletionParameters
-import com.intellij.codeInsight.completion.CompletionProvider
-import com.intellij.codeInsight.completion.CompletionResultSet
-import com.intellij.codeInsight.completion.PrefixMatcher
-import com.intellij.codeInsight.lookup.LookupElementBuilder
+import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.openapi.actionSystem.impl.SimpleDataContext
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.editor.actionSystem.EditorActionManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.text.StringUtil
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiElement
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.childrenOfType
+import com.intellij.psi.util.parentOfType
 import com.intellij.util.ProcessingContext
 import com.intellij.util.indexing.FileBasedIndex
+import com.intellij.util.text.NameUtilCore
+import com.jetbrains.php.PhpIndex
 import com.jetbrains.php.drupal.DrupalVersion
 import com.jetbrains.php.drupal.hooks.DrupalHooksIndex
 import com.jetbrains.php.drupal.settings.DrupalDataService
-import com.jetbrains.php.lang.psi.elements.ParameterList
-import com.jetbrains.php.lang.psi.elements.PhpAttribute
-import com.jetbrains.php.lang.psi.elements.StringLiteralExpression
+import com.jetbrains.php.lang.psi.PhpPsiElementFactory
+import com.jetbrains.php.lang.psi.PhpPsiUtil
+import com.jetbrains.php.lang.psi.elements.*
+import com.jetbrains.php.lang.psi.elements.Function
+import com.jetbrains.php.lang.psi.elements.impl.MethodImpl
+import com.jetbrains.php.lang.psi.elements.impl.PhpAttributesListImpl
+import com.jetbrains.php.lang.psi.elements.impl.PhpClassImpl
 import com.jetbrains.php.lang.psi.stubs.indexes.PhpFunctionNameIndex
 
 class HookAttributeCompletionProvider: CompletionProvider<CompletionParameters>() {
@@ -50,7 +61,7 @@ class HookAttributeCompletionProvider: CompletionProvider<CompletionParameters>(
         hookNames.addAll(functionNamesFromDocs)
 
         for (name in hookNames) {
-            completionResultSet.addElement(LookupElementBuilder.create(name))
+            completionResultSet.addElement(HookImplementationLookupElement(name))
         }
     }
 
@@ -97,5 +108,124 @@ class HookAttributeCompletionProvider: CompletionProvider<CompletionParameters>(
         }
 
         return filtered
+    }
+
+    class HookImplementationLookupElement(private val hookName: String): LookupElement() {
+
+        override fun getLookupString(): String {
+            return hookName;
+        }
+
+        override fun handleInsert(context: InsertionContext) {
+            super.handleInsert(context)
+
+            val element = context.file.findElementAt(context.startOffset) ?: return
+            val attributeListImpl = PsiTreeUtil.getParentOfType(element, PhpAttributesListImpl::class.java) ?: return
+            // Do not insert method if hook attribute is on class.
+            if (attributeListImpl.parent is PhpClassImpl) return
+            // Ideally we prevent inserting the method if a second hook attribute is added to a function, but this will
+            // cause false positive checks if there is any hook function under, even separated by a new lines.
+//            val methodImpl = PsiTreeUtil.getParentOfType(attributeListImpl, MethodImpl::class.java);
+//            if (methodImpl != null) {
+//                val attributes = PsiTreeUtil.getChildrenOfType(methodImpl, PhpAttributesListImpl::class.java)
+//                var count = 0;
+//                attributes?.forEach {
+//                    it.childrenOfType<PhpAttribute>().forEach { attrClazz ->
+//                        if (attrClazz.fqn == "\\Drupal\\Core\\Hook\\Attribute\\Hook") {
+//                            count++
+//                        }
+//                        if (count > 1) {
+//                            return
+//                        }
+//                    }
+//                }
+//            }
+            addMethodImpl(context)
+        }
+
+        private fun addMethodImpl(context: InsertionContext) {
+            val editor = context.editor
+            val project = editor.project ?: return;
+            val element = context.file.findElementAt(context.startOffset) ?: return
+            val doc: Document = editor.document
+            val docManager = PsiDocumentManager.getInstance(project)
+            val attributeList = PsiTreeUtil.getParentOfType(element, PhpAttributesListImpl::class.java) ?: return
+            val simpleContext = SimpleDataContext.getProjectContext(project)
+            val currentCaret = editor.caretModel.currentCaret
+
+            // Get a parameter list from the hook example in api.php file if present.
+            val docFunction = getDescriptiveFunctionByHookName(hookName, context.project)
+            var parameterListText = ""
+            if (docFunction != null) {
+                val parameterList =
+                    PhpPsiUtil.getChildByCondition<PsiElement>(docFunction, ParameterList.INSTANCEOF) as ParameterList?
+                if (parameterList != null) {
+                    parameterListText = parameterList.text
+                }
+            }
+
+            val functionName = convertToCamelCaseString(hookName)
+
+            attributeList.parent.addAfter(
+                PhpPsiElementFactory.createMethod(project, "public function $functionName($parameterListText) {}"),
+                attributeList
+            )
+            if (docManager.isDocumentBlockedByPsi(doc)) {
+                docManager.doPostponedOperationsAndUnblockDocument(doc)
+            }
+            docManager.commitDocument(doc)
+
+            editor.caretModel.moveToOffset(attributeList.textRange.endOffset, true)
+            EditorActionManager.getInstance().getActionHandler("EditorEnter").execute(
+                editor,
+                currentCaret,
+                simpleContext
+            )
+            docManager.commitDocument(doc)
+            val position = element.parentOfType<MethodImpl>()?.childrenOfType<GroupStatement>()?.first()?.textOffset ?: return
+            editor.caretModel.moveToOffset(position + 1)
+            EditorActionManager.getInstance().getActionHandler("EditorEnter").execute(editor, currentCaret, simpleContext)
+        }
+
+        private fun getDescriptiveFunctionByHookName(hookName: String, project: Project): Function? {
+            val dataService = DrupalDataService.getInstance(project)
+            if (dataService.isEnabled && dataService.isVersionValid) {
+                val functionName = "hook_$hookName"
+
+                for (suitableFunction in PhpIndex.getInstance(project).getFunctionsByName(functionName)) {
+                    val containingFile = suitableFunction.containingFile
+                    if (containingFile != null) {
+                        val fileName = containingFile.name
+                        if (fileName.endsWith(".api.php")) {
+                            return suitableFunction
+                        }
+                    }
+                }
+
+                return null
+            } else {
+                return null
+            }
+        }
+
+        private fun convertToCamelCaseString(text: String): String {
+            val strings: Array<String> = NameUtilCore.nameToWords(text)
+            if (strings.isNotEmpty()) {
+                val buf = StringBuilder()
+                buf.append(StringUtil.toLowerCase(strings[0]))
+
+                for (i in 1..<strings.size) {
+                    val string = strings[i]
+                    if (Character.isLetterOrDigit(string[0])) {
+                        buf.append(StringUtil.capitalize(StringUtil.toLowerCase(string)))
+                    }
+                }
+
+                return buf.toString()
+            } else {
+                return ""
+            }
+        }
+
     }
 }


### PR DESCRIPTION
The function will be inserted when the plugin completes the hook name.
A possible problem is that if the user wants to add a second hook to an existing function, we don't check that and the new function will be inserted anyway.
But a naive check will cause the function to not be inserted if the is any hook function under, even if the user wants to add a new hook function, which I think is the case more often, so the check is disabled for now.


  